### PR TITLE
Registra saida de aeronaves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv
+__pycache__

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ O Aeroporto de Pato Branco recebe aeronaves  diariamente e atualmente faz o cont
 |--------|--------|----------|
 | [Novo Registro](#novo-registro) | POST   | /aeronaves |
 | [Listar](#listar) | GET   | /aeronaves/listar |
-| [Atualizar](#atualizar) | PATCH   | /endereço/:param/... |
+| [Atualizar](#atualizar) | PATCH   | /aeronaves/{nome}/partida|
 | [Deletar](#deletar) | DELETE   | /endereço/:param/... |
 
 ---
@@ -32,14 +32,22 @@ Desc: Inclui novo registro de chegada de aeronave no pátio
 ```json
 BODY
 {
-  "nome": "Nome"
+  "nome": "string",
+  "data_entrada": "datetime" //opcional
 }
 ```
+
+##### Respostas
+| código | Descrição |
+|--------|--------|
+| 200 | OK |
+| 400 | Aeronave já registrada |
+| 422 | Validation Error |
 ---
 
 #### Listar
 
-Desc: Lista aeronaves presentes no pát
+Desc: Lista aeronaves presentes no pátio
 
 **GET** (/aeronaves/listar)
 ```json
@@ -50,15 +58,17 @@ BODY
 
 #### Atualizar
 
-Desc: 
+Desc: Registra a partida das aeronaves do pátio
 
-**PATCH** (/endereço/:param/...)
-```json
-BODY
-{  
-    "parâmetro 1": "UPDATE",  
-}
-```
+**PATCH** (/aeronaves/{nome}/partida)
+
+##### Respostas
+| código | Descrição |
+|--------|--------|
+| 200 | OK |
+| 404 | Aeronave não encontrada |
+| 422 | Validation Error |
+
 ---
 #### Deletar
 

--- a/README.md
+++ b/README.md
@@ -18,31 +18,30 @@ O Aeroporto de Pato Branco recebe aeronaves  diariamente e atualmente faz o cont
 ##### Sumário
 | Função | Método | Endereço |
 |--------|--------|----------|
-| [Novo Registro](#novo-registro) | POST   | /endereço/... |
-| [Listar](#listar) | GET   | /endereço/... |
+| [Novo Registro](#novo-registro) | POST   | /aeronaves |
+| [Listar](#listar) | GET   | /aeronaves/listar |
 | [Atualizar](#atualizar) | PATCH   | /endereço/:param/... |
 | [Deletar](#deletar) | DELETE   | /endereço/:param/... |
 
 ---
 #### Novo Registro
 
-Desc: 
+Desc: Inclui novo registro de chegada de aeronave no pátio
 
-**POST** (/endereço/...)
+**POST** (/aeronaves/...)
 ```json
 BODY
-{    
-    "parâmetro 1": "texto",    
-    "parâmetro 2": 10000
+{
+  "nome": "Nome"
 }
 ```
 ---
 
 #### Listar
 
-Desc: 
+Desc: Lista aeronaves presentes no pát
 
-**GET** (/endereço/...)
+**GET** (/aeronaves/listar)
 ```json
 BODY
 {    }

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, HTTPException
 from pydantic import BaseModel
 from datetime import datetime
+import json
+
 
 app = FastAPI()
 
@@ -17,13 +19,25 @@ aeronaves_db = []
 
 @app.get("/aeronaves/listar", response_model=aeronaves_db)
 def listar_aeronaves():    
-    return list(filter(lambda aeronave: aeronave.data_saida != None, aeronaves_db))
+    return list(filter(lambda aeronave: aeronave.data_saida is None, aeronaves_db))
 
 @app.post("/aeronaves/", response_model=Aeronave)
 def create_aeronave(aeronave: Aeronave):
+    if next((a for a in aeronaves_db if a.data_saida is None and a.nome == aeronave.nome), None):
+        raise HTTPException(status_code=400, detail="Aeronave já registrada")
+
     aeronave.id = len(aeronaves_db) + 1
     aeronave.data_saida = None
     aeronaves_db.append(aeronave)
     return aeronave
+
+@app.patch("/aeronaves/{nome}/partida", response_model=Aeronave)
+async def atualizar_aeronave(nome: str):
+    for registro in list(filter(lambda aeronave: aeronave.data_saida is None, aeronaves_db)):
+        if registro.data_saida == None and registro.nome == nome:
+            registro.data_saida = datetime.now()
+            return registro
+
+    raise HTTPException(status_code=404, detail="Aeronave não encontrada")
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,21 +4,26 @@ from datetime import datetime
 
 app = FastAPI()
 
-class Aeronave(BaseModel):
-    id: int
-    nome: str
-    data_entrada: datetime
-    data_saida: datetime
+class Aeronave(BaseModel):    
 
-# Piazada, vamo adicionar as naves no array.
+    id: int = 0
+    nome: str
+    data_entrada: datetime = datetime.now()
+    data_saida: datetime = None
+
+
 aeronaves_db = []
+
+
+@app.get("/aeronaves/listar", response_model=aeronaves_db)
+def listar_aeronaves():    
+    return list(filter(lambda aeronave: aeronave.data_saida != None, aeronaves_db))
 
 @app.post("/aeronaves/", response_model=Aeronave)
 def create_aeronave(aeronave: Aeronave):
     aeronave.id = len(aeronaves_db) + 1
+    aeronave.data_saida = None
     aeronaves_db.append(aeronave)
     return aeronave
 
-@app.get("/aeronaves/listar", response_model=aeronaves_db)
-def listar_aeronaves():
-    return aeronaves_db
+


### PR DESCRIPTION
Add valores padrão nos parâmetros da classe Aeronave.

Ajuste função post, agora é necessário informar somente o nome da aeronave, ainda podendo informar a data de entrada, mas bloqueando parâmetros ID e data_saida.

Ajuste função get, validado regra de negócio onde deve-se listar somente aeronaves no pátio (sem data_saida).

Add função patch na Rota /aeronaves/{nome}/partida, valida os registros, e preenche com a data atual o campo data_saída onde o registro possuir data_saida nula e nome correspondente ao passado na rota.

Atualizado documentação do README.md.

Adicionado pasta __pycache__ ao .gitignore.